### PR TITLE
ClientID required for all TwitchClients

### DIFF
--- a/TwitchCSharp/Clients/TwitchAuthenticatedClient.cs
+++ b/TwitchCSharp/Clients/TwitchAuthenticatedClient.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using RestSharp;
 using TwitchCSharp.Enums;
 using TwitchCSharp.Helpers;
@@ -10,13 +10,11 @@ namespace TwitchCSharp.Clients
     {
 
         private readonly string oauth;
-        private readonly string clientId;
         private readonly string username;
 
-        public TwitchAuthenticatedClient(string oauth, string clientId) : base()
+        public TwitchAuthenticatedClient(string clientId, string oauth) : base(clientId)
         {
             this.oauth = oauth;
-            this.clientId = clientId;
 
             var user = this.GetMyUser();
             if (user == null || String.IsNullOrWhiteSpace(user.Name))
@@ -210,7 +208,6 @@ namespace TwitchCSharp.Clients
         public RestRequest GetRequest(string url, Method method)
         {
             RestRequest restRequest = new RestRequest(url, method);
-            restRequest.AddHeader("Client-ID", clientId);
             restRequest.AddHeader("Authorization", String.Format("OAuth {0}", oauth));
             return restRequest;
         }

--- a/TwitchCSharp/Clients/TwitchReadOnlyClient.cs
+++ b/TwitchCSharp/Clients/TwitchReadOnlyClient.cs
@@ -1,4 +1,4 @@
-﻿using RestSharp;
+using RestSharp;
 using TwitchCSharp.Enums;
 using TwitchCSharp.Helpers;
 using TwitchCSharp.Models;
@@ -10,15 +10,12 @@ namespace TwitchCSharp.Clients
 
         public readonly RestClient restClient;
 
-        public TwitchReadOnlyClient() : this(TwitchHelper.twitchApiUrl)
-        {
-        }
-
-        public TwitchReadOnlyClient(string url)
+        public TwitchReadOnlyClient(string clientID, string url = TwitchHelper.twitchApiUrl)
         {
             restClient = new RestClient(url);
             restClient.AddHandler("application/json", new DynamicJsonDeserializer());
             restClient.AddDefaultHeader("Accept", TwitchHelper.twitchAcceptHeader);
+            restClient.AddDefaultHeader("Client-ID", clientID);
         }
 
         public Channel GetChannel(string channel)


### PR DESCRIPTION
Twitch API calls to Kraken will require a Client-ID to be submitted with every request.

Read more here:
https://blog.twitch.tv/client-id-required-for-kraken-api-calls-afbb8e95f843

This commit ensures a Client ID is specified for both the `TwitchReadOnlyClient` and `TwitchAuthenticatedClient`.
